### PR TITLE
Fix `git_remote_connect` eating exceptions

### DIFF
--- a/LibGit2Sharp/Core/Proxy.cs
+++ b/LibGit2Sharp/Core/Proxy.cs
@@ -2172,6 +2172,7 @@ namespace LibGit2Sharp.Core
             catch (Exception)
             {
                 customHeaders.Dispose();
+                throw;
             }
         }
 


### PR DESCRIPTION
Fixes an issue where calling `Repository.ListRemoteReferences` would sometimes throw an exception saying `this remote has never connected`. This won't prevent that error from occurring, but it'll provide the real error that's causing it.