### PR TITLE
Add new method for adding worktree for referenced branch

### DIFF
--- a/LibGit2Sharp/WorktreeCollection.cs
+++ b/LibGit2Sharp/WorktreeCollection.cs
@@ -48,7 +48,43 @@ namespace LibGit2Sharp
         }
 
         /// <summary>
-        /// 
+        ///
+        /// </summary>
+        /// <param name="branch"></param>
+        /// <param name="name"></param>
+        /// <param name="path"></param>
+        /// <param name="isLocked"></param>
+        /// <returns></returns>
+        public virtual Worktree Add(Branch branch, string name, string path, bool isLocked)
+        {
+            git_worktree_add_options options = new git_worktree_add_options
+            {
+                version = 1,
+                locked = Convert.ToInt32(isLocked)
+            };
+
+            // Proxy.git_worktree_add() can take a branch reference to create the branch for. This will correctly check
+            // out the tracked branch (rather than being in a detached head state).
+
+            Worktree worktree;
+            using (var referencePtr = repo.Refs.RetrieveReferencePtr(branch.CanonicalName))
+            {
+                options.@ref = referencePtr?.AsIntPtr() ?? options.@ref;
+
+                using (var handle = Proxy.git_worktree_add(repo.Handle, name, path, options))
+                {
+                    worktree = new Worktree(
+                        repo,
+                        name,
+                        Proxy.git_worktree_is_locked(handle));
+                }
+            }
+
+            return worktree;
+        }
+
+        /// <summary>
+        ///
         /// </summary>
         /// <param name="committishOrBranchSpec"></param>
         /// <param name="name"></param>


### PR DESCRIPTION
This method passes the ref to LibGit2, allowing creation of a worktree from a branch without creating a new branch for the worktree.