### PR TITLE
Set the native libgit2 error message when an exception is thrown in the subtransport

### DIFF
--- a/LibGit2Sharp/SmartSubtransportStream.cs
+++ b/LibGit2Sharp/SmartSubtransportStream.cs
@@ -119,6 +119,10 @@ namespace LibGit2Sharp
                 {
                     errorCode = ((NativeException)ret).ErrorCode;
                 }
+                else
+                {
+                    Proxy.git_error_set_str(GitErrorCategory.Unknown, caught);
+                }
 
                 return (int)errorCode;
             }


### PR DESCRIPTION
This was originally added when we last had the custom transport and needs to be re-added: https://github.com/OctopusDeploy/libgit2sharp/pull/4