### PR TITLE
Do not use string formatting LibGit2SharpException constructor

### DIFF
--- a/LibGit2Sharp/Core/Ensure.cs
+++ b/LibGit2Sharp/Core/Ensure.cs
@@ -148,7 +148,7 @@ namespace LibGit2Sharp.Core
             Func<string, GitErrorCategory, LibGit2SharpException> exceptionBuilder;
             if (!GitErrorsToLibGit2SharpExceptions.TryGetValue((GitErrorCode)result, out exceptionBuilder))
             {
-                exceptionBuilder = (m, c) => new LibGit2SharpException(m, c);
+                exceptionBuilder = (m, c) => new LibGit2SharpException(m);
             }
 
             throw exceptionBuilder(errorMessage, errorCategory);


### PR DESCRIPTION
The exception constructors in `GitErrorsToLibGit2SharpExceptions` make use of the error category by passing it through to the `NativeException(string message, GitErrorCategory category)` constructor which adds `("libgit2.category", category)` to `Data` on `System.Exception`.

We were calling new `LibGit2SharpException(m, c)`, but this was resolving to the string formatting constructor on LibGit2SharpException, because it does not have a constructor that takes a category. This runs a string format, so if the `errorMessage` contained any curly braces, that constructor would throw an `System.FormatException`.

This has been changed to just use the message constructor (with no format arguments), and will drop the error code (which is always Unknown anyway)