### PR TITLE
Update to `actions/upload-artifact` v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Build
         run: dotnet build LibGit2Sharp.sln --configuration Release
       - name: Upload packages
-        uses: actions/upload-artifact@v3.1.2
+        uses: actions/upload-artifact@v4.4.3
         with:
           name: NuGet packages
           path: bin/Packages/


### PR DESCRIPTION
[V3 of artifact actions are being deprecated on Nov 30th 2024](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/) after which time workflows will fail. This PR updates to use v4 - other actions are pinned in this repo so I've opted to use the latest: `v4.4.3`.