### PR TITLE
Re-introduce .net6 while we still have Calamari running in .net6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       matrix:
         arch: [ x64 ]
         os: [ windows-2022, macos-13 ]
-        tfm: [ net472, net8.0, net9.0 ]
+        tfm: [ net472, net6.0, net8.0, net9.0 ]
         exclude:
           - os: macos-13
             tfm: net472
@@ -63,6 +63,7 @@ jobs:
           dotnet-version: |
             9.0.x
             8.0.x
+            6.0.x
       - name: Run ${{ matrix.tfm }} tests
         run: dotnet test LibGit2Sharp.sln --configuration Release --framework ${{ matrix.tfm }} --logger "GitHubActions" /p:ExtraDefine=LEAKS_IDENTIFYING
   test-linux:
@@ -81,6 +82,8 @@ jobs:
           - distro: alpine.3.19
             sdk: '9.0'
         include:
+          - sdk: '6.0'
+            tfm: net6.0
           - sdk: '8.0'
             tfm: net8.0
           - sdk: '9.0'

--- a/.idea/.idea.LibGit2Sharp/.idea/.gitignore
+++ b/.idea/.idea.LibGit2Sharp/.idea/.gitignore
@@ -1,0 +1,13 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Rider ignored files
+/contentModel.xml
+/projectSettingsUpdater.xml
+/modules.xml
+/.idea.LibGit2Sharp.iml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/.idea.LibGit2Sharp/.idea/.name
+++ b/.idea/.idea.LibGit2Sharp/.idea/.name
@@ -1,0 +1,1 @@
+LibGit2Sharp

--- a/.idea/.idea.LibGit2Sharp/.idea/encodings.xml
+++ b/.idea/.idea.LibGit2Sharp/.idea/encodings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding" addBOMForNewFiles="with BOM under Windows, with no BOM otherwise" />
+</project>

--- a/.idea/.idea.LibGit2Sharp/.idea/indexLayout.xml
+++ b/.idea/.idea.LibGit2Sharp/.idea/indexLayout.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="UserContentModel">
+    <attachedFolders />
+    <explicitIncludes />
+    <explicitExcludes />
+  </component>
+</project>

--- a/.idea/.idea.LibGit2Sharp/.idea/vcs.xml
+++ b/.idea/.idea.LibGit2Sharp/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj
+++ b/LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(TargetFrameworks)'==''">net472;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetFrameworks)'==''">net472;net6.0;net8.0;net9.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;net8.0</TargetFrameworks>
+    <TargetFrameworks>net472;net8.0;net6.0</TargetFrameworks>
     <LangVersion>12.0</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>LibGit2Sharp brings all the might and speed of libgit2, a native Git implementation, to the managed world of .NET</Description>
@@ -26,6 +26,9 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <IsTrimmable>true</IsTrimmable>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>
 


### PR DESCRIPTION
Hopefully this is only required for a short time before we update calamari