### PR TITLE
Merge pull request #18 from OctopusDeploy/robe/include-net6

### DIFF
--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net472;net8.0;net6.0</TargetFrameworks>
-    <LangVersion>12.0</LangVersion>
+    <LangVersion>10.0</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>LibGit2Sharp brings all the might and speed of libgit2, a native Git implementation, to the managed world of .NET</Description>
     <Company>LibGit2Sharp contributors</Company>


### PR DESCRIPTION
Re-introduce .net6 while we still have Calamari running in .net6