### PR TITLE
Update to build process

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,10 +39,10 @@ jobs:
     strategy:
       matrix:
         arch: [ x64 ]
-        os: [ windows-2022, macos-13 ]
+        os: [ windows-2022, macos-14 ]
         tfm: [ net472, net8.0, net9.0 ]
         exclude:
-          - os: macos-13
+          - os: macos-14
             tfm: net472
         include:
           - arch: arm64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       matrix:
         arch: [ x64 ]
         os: [ windows-2022, macos-13 ]
-        tfm: [ net472, net6.0, net8.0, net9.0 ]
+        tfm: [ net472, net8.0, net9.0 ]
         exclude:
           - os: macos-13
             tfm: net472
@@ -63,7 +63,6 @@ jobs:
           dotnet-version: |
             9.0.x
             8.0.x
-            6.0.x
       - name: Run ${{ matrix.tfm }} tests
         run: dotnet test LibGit2Sharp.sln --configuration Release --framework ${{ matrix.tfm }} --logger "GitHubActions" /p:ExtraDefine=LEAKS_IDENTIFYING
   test-linux:
@@ -82,8 +81,6 @@ jobs:
           - distro: alpine.3.19
             sdk: '9.0'
         include:
-          - sdk: '6.0'
-            tfm: net6.0
           - sdk: '8.0'
             tfm: net8.0
           - sdk: '9.0'

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net8.0</TargetFrameworks>
     <LangVersion>12.0</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>LibGit2Sharp brings all the might and speed of libgit2, a native Git implementation, to the managed world of .NET</Description>
@@ -26,9 +26,6 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <IsTrimmable>true</IsTrimmable>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>
 


### PR DESCRIPTION
# Context 🌆 
We recently needed to make changes to our fork of libgit2sharp, and found the build process was not working. This PR fixes the build process.

# Details 🔍 
There are two main parts to this

## Remove .NET 6.0 support
.Net6.0 support was reintroduced in "[Re-introduce .net6 while we still have Calamari running in .net6](https://github.com/OctopusDeploy/libgit2sharp/pull/18)". Since then, Calamari has updated to  .NET 8 and removed support for .NET 6.0([here](https://github.com/OctopusDeploy/Calamari/pull/1528)) . As such, we can nwt remove support for .NET 6 from this project.


## MacOS-13 is a retired runner
Macintosh OS 13 has been[ retired as a runner](https://github.com/actions/runner-images/issues/13046) for GitHub Actions. This prevents the macOS tests from running successfully. I have updated the OS for these tests to macOS-14, and it now runs successfully.

## Ideally, this would be a PR that we could submit for the main fork
Unfortunately, without both these changes, I cannot get a green build. In order to merge either of them, I need to include both. The macOS update should be all that is required by the parent fork. They already do not support .NET 6.  I will not squash these two commits in this PR. I will then create a separate standalone PR with macOS change for the parent fork.

[sc-131120]
