### PR TITLE
Add nightly build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,12 +7,6 @@ on:
       - '[0-9]+.[0-9]+.[0-9]+-*'
   pull_request:
   workflow_dispatch:
-    inputs:
-      nightly:
-        description: 'Build as nightly version'
-        required: false
-        type: boolean
-        default: false
   schedule:
     - cron: '0 15 * * *'  # Run at 3 PM UTC (1 AM Melbourne AEST / 2 AM AEDT)
 env:
@@ -35,13 +29,12 @@ jobs:
           # if it is a pull request build set the build identity to branchname.runnumber
           if ("${{ github.event_name }}" -eq "pull_request" -and "${{ github.head_ref }}" -ne "") {
             $branchName = "${{ github.head_ref }}" -replace '[/\\]', '-' -replace '[^a-zA-Z0-9\-]', ''
-            $buildIdentity = "$branchName.${{ github.run_number }}"
             
-            $env:BUILD_IDENTITY = $buildIdentity
+            $env:BUILD_IDENTITY = "$branchName.${{ github.run_number }}"
           }
           
           # if it is a scheduled build set the build identity to nightly
-          if ("${{ github.event_name }}" -eq "schedule" -or "${{ inputs.nightly }}" -eq "true") {
+          if ("${{ github.event_name }}" -eq "schedule") {
             $env:BUILD_IDENTITY = "nightly.${{ github.run_number }}"
           }
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,14 @@ on:
       - '[0-9]+.[0-9]+.[0-9]+-*'
   pull_request:
   workflow_dispatch:
+    inputs:
+      nightly:
+        description: 'Build as nightly version'
+        required: false
+        type: boolean
+        default: false
+  schedule:
+    - cron: '0 15 * * *'  # Run at 3 PM UTC (1 AM Melbourne AEST / 2 AM AEDT)
 env:
   DOTNET_NOLOGO: true
 jobs:
@@ -23,7 +31,22 @@ jobs:
         with:
           dotnet-version: 9.0.x
       - name: Build
-        run: dotnet build LibGit2Sharp.sln --configuration Release
+        run: |
+          # if it is a pull request build set the build identity to branchname.runnumber
+          if ("${{ github.event_name }}" -eq "pull_request" -and "${{ github.head_ref }}" -ne "") {
+            $branchName = "${{ github.head_ref }}" -replace '[/\\]', '-' -replace '[^a-zA-Z0-9\-]', ''
+            $buildIdentity = "$branchName.${{ github.run_number }}"
+            
+            $env:BUILD_IDENTITY = $buildIdentity
+          }
+          
+          # if it is a scheduled build set the build identity to nightly
+          if ("${{ github.event_name }}" -eq "schedule" -or "${{ inputs.nightly }}" -eq "true") {
+            $env:BUILD_IDENTITY = "nightly.${{ github.run_number }}"
+          }
+
+          dotnet build LibGit2Sharp.sln --configuration Release
+        shell: pwsh
       - name: Upload packages
         uses: actions/upload-artifact@v4.3.1
         with:
@@ -105,7 +128,7 @@ jobs:
     name: Octopus NuGet Push
     needs: [build, test, test-linux]
     # &&  github.ref == 'refs/heads/octopus/master'
-    if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]' && github.event_name != 'schedule'
+    if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/download-artifact@v4

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -31,6 +31,7 @@
 
   <PropertyGroup Condition="'$(BUILD_IDENTITY)' != ''">
     <MinVerDefaultPreReleaseIdentifiers>octopus-$(BUILD_IDENTITY)</MinVerDefaultPreReleaseIdentifiers>
+    <MinVerIgnoreHeight>true</MinVerIgnoreHeight>
   </PropertyGroup> 
 
   <ItemGroup>

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -29,6 +29,10 @@
     <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(BUILD_IDENTITY)' != ''">
+    <MinVerDefaultPreReleaseIdentifiers>octopus-$(BUILD_IDENTITY)</MinVerDefaultPreReleaseIdentifiers>
+  </PropertyGroup> 
+
   <ItemGroup>
     <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="[2.0.323]" PrivateAssets="none" />
     <PackageReference Include="MinVer" Version="6.0.0" PrivateAssets="all" />

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -31,7 +31,6 @@
 
   <PropertyGroup Condition="'$(BUILD_IDENTITY)' != ''">
     <MinVerDefaultPreReleaseIdentifiers>octopus-$(BUILD_IDENTITY)</MinVerDefaultPreReleaseIdentifiers>
-    <MinVerIgnoreHeight>true</MinVerIgnoreHeight>
   </PropertyGroup> 
 
   <ItemGroup>


### PR DESCRIPTION
# Context 🌆 
Our build pipeline was broken, and we didn't realize it until we needed to make a change to this library. We want to initiate nightly builds so we can detect a broken pipeline early and fix it before it becomes a problem. We also could not publish from our branch after the first build of that branch.

# Details 🔍 
In order to create branch builds and nightly builds, we need to override the `MinVerDefaultPreReleaseIdentifiers`. The documentation implies we can do this with an environment variable. Unfortunately, when I do this, the `MinVerDefaultPreReleaseIdentifiers` is ignored completely. Creating a conditional property group in the `csproj` file works reliably and allows us to maintain a fairly clean CI process.

The alternative was to set `MINVERVERSIONOVERRIDE`, but this required us to derive the current version number, which was generally more complicated.

I would also like to ignore the height value when creating version numbers. This value is not calculated correctly for GitHub PRs, which is why we need to do this customer naming for our branch builds. If I set `MinVerIgnoreHeight` in the `csproj` file it completely ignored the `MinVerDefaultPreReleaseIdentifiers`. As this value can only change by pushing a new tag or merging into master, it is acceptable.

## Branch build
<img width="911" height="171" alt="chrome_fzofvT9mSS" src="https://github.com/user-attachments/assets/096e40f3-c895-4b4f-9f49-48badd4e1cfe" />

## Nightly build
<img width="992" height="150" alt="chrome_Yj8iPzkPhS" src="https://github.com/user-attachments/assets/ef96a1a4-e5b8-468f-9317-1d6202e1cdab" />

## With ignore height turn on in csproj
<img width="787" height="201" alt="image" src="https://github.com/user-attachments/assets/ee84e588-731a-4bc8-9581-2b407451708f" />


[sc-131121]
