### PR TITLE
Update libgit2 native binaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,120 +1,133 @@
 name: CI
 on:
-  push:
-    branches: [master, release-*]
-    tags:
-      - '[0-9]+.[0-9]+.[0-9]+'
-      - '[0-9]+.[0-9]+.[0-9]+-*'
-  pull_request:
-  workflow_dispatch:
+    push:
+        branches: [master, release-*]
+        tags:
+            - "[0-9]+.[0-9]+.[0-9]+"
+            - "[0-9]+.[0-9]+.[0-9]+-*"
+    pull_request:
+    workflow_dispatch:
 env:
-  DOTNET_NOLOGO: true
+    DOTNET_NOLOGO: true
 jobs:
-  build:
-    name: Build
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4.1.2
-        with:
-          fetch-depth: 0
-      - name: Install .NET SDK
-        uses: actions/setup-dotnet@v4.0.0
-        with:
-          dotnet-version: 9.0.x
-      - name: Build
-        run: dotnet build LibGit2Sharp.sln --configuration Release
-      - name: Upload packages
-        uses: actions/upload-artifact@v4.3.1
-        with:
-          name: NuGet packages
-          path: artifacts/package/
-          retention-days: 7
-      - name: Verify trimming compatibility
-        run: dotnet publish TrimmingTestApp
-      
-  test:
-    name: Test / ${{ matrix.os }} / ${{ matrix.arch }} / ${{ matrix.tfm }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        arch: [ x64 ]
-        os: [ windows-2022, macos-14 ]
-        tfm: [ net472, net8.0, net9.0 ]
-        exclude:
-          - os: macos-14
-            tfm: net472
-        include:
-          - arch: arm64
-            os: macos-14
-            tfm: net8.0
-          - arch: arm64
-            os: macos-14
-            tfm: net9.0
-      fail-fast: false
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4.1.2
-        with:
-          fetch-depth: 0
-      - name: Install .NET SDK
-        uses: actions/setup-dotnet@v4.0.0
-        with:
-          dotnet-version: |
-            9.0.x
-            8.0.x
-      - name: Run ${{ matrix.tfm }} tests
-        run: dotnet test LibGit2Sharp.sln --configuration Release --framework ${{ matrix.tfm }} --logger "GitHubActions" /p:ExtraDefine=LEAKS_IDENTIFYING
-  test-linux:
-    name: Test / ${{ matrix.distro }} / ${{ matrix.arch }} / ${{ matrix.tfm }}
-    runs-on: ${{ matrix.runnerImage }}
-    strategy:
-      matrix:
-        arch: [ amd64, arm64 ]
-        distro: [ alpine.3.17, alpine.3.18, alpine.3.19, alpine.3.20, centos.stream.9, debian.12, fedora.40, ubuntu.20.04, ubuntu.22.04, ubuntu.24.04 ]
-        sdk:  [ '8.0', '9.0' ]
-        exclude:
-          - distro: alpine.3.17
-            sdk: '9.0'
-          - distro: alpine.3.18
-            sdk: '9.0'
-          - distro: alpine.3.19
-            sdk: '9.0'
-        include:
-          - sdk: '8.0'
-            tfm: net8.0
-          - sdk: '9.0'
-            tfm: net9.0
-          - arch: amd64
-            runnerImage: ubuntu-22.04
-          - arch: arm64
-            runnerImage: ubuntu-22.04-arm
-      fail-fast: false
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4.1.2
-        with:
-          fetch-depth: 0
-      - name: Run ${{ matrix.tfm }} tests
-        run: |
-            git_command="git config --global --add safe.directory /app"
-            test_command="dotnet test LibGit2Sharp.sln --configuration Release -p:TargetFrameworks=${{ matrix.tfm }} --logger "GitHubActions" -p:ExtraDefine=LEAKS_IDENTIFYING"
-            docker run -t --rm --platform linux/${{ matrix.arch }} -v "$PWD:/app" -e OPENSSL_ENABLE_SHA1_SIGNATURES=1 gittools/build-images:${{ matrix.distro }}-sdk-${{ matrix.sdk }} sh -c "$git_command && $test_command"
-  
-  nuget-push:
-    name: Octopus NuGet Push
-    needs: [build, test, test-linux]
-    # &&  github.ref == 'refs/heads/octopus/master'
-    if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]' && github.event_name != 'schedule'
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/download-artifact@v4
-        with:
-          path: staging
-      - name: Push package to feed 🐙
-        id: push-feed
-        shell: bash
-        env:
-          FEED_API_KEY: ${{ secrets.FEED_API_KEY }}
-          FEED_SOURCE: ${{ secrets.FEED_SOURCE }}
-        run: dotnet nuget push staging/**/*.nupkg --api-key "$FEED_API_KEY" --source "$FEED_SOURCE"
+    build:
+        name: Build
+        runs-on: ubuntu-22.04
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v6
+              with:
+                  fetch-depth: 0
+            - name: Install .NET SDK
+              uses: actions/setup-dotnet@v5
+              with:
+                  dotnet-version: 9.0.x
+            - name: Compute version suffix for branch builds
+              if: ${{ !startsWith(github.ref, 'refs/tags/') }}
+              id: version
+              run: |
+                  # Sanitize branch name: lowercase, replace non-alphanumeric with hyphen, trim to 20 chars
+                  BRANCH="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}"
+                  SAFE_BRANCH=$(echo "$BRANCH" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | sed 's/^-//' | sed 's/-$//' | cut -c1-20)
+                  echo "override=${SAFE_BRANCH}.${{ github.run_number }}" >> "$GITHUB_OUTPUT"
+            - name: Build
+              run: dotnet build LibGit2Sharp.sln --configuration Release ${{ steps.version.outputs.override && format('/p:MinVerDefaultPreReleaseIdentifiers="{0}"', steps.version.outputs.override) || '' }}
+            - name: Upload packages
+              uses: actions/upload-artifact@v7
+              with:
+                  name: NuGet packages
+                  path: artifacts/package/
+                  retention-days: 7
+            - name: Verify trimming compatibility
+              run: dotnet publish TrimmingTestApp
+
+    test:
+        name: Test / ${{ matrix.os }} / ${{ matrix.arch }} / ${{ matrix.tfm }}
+        runs-on: ${{ matrix.os }}
+        strategy:
+            matrix:
+                arch: [x64]
+                os: [windows-2022, macos-14]
+                tfm: [net472, net8.0, net9.0]
+                exclude:
+                    - os: macos-14
+                      tfm: net472
+                include:
+                    - arch: arm64
+                      os: macos-14
+                      tfm: net8.0
+                    - arch: arm64
+                      os: macos-14
+                      tfm: net9.0
+            fail-fast: false
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v6
+              with:
+                  fetch-depth: 0
+            - name: Install .NET SDK
+              uses: actions/setup-dotnet@v5
+              with:
+                  dotnet-version: |
+                      9.0.x
+                      8.0.x
+            - name: Run ${{ matrix.tfm }} tests
+              run: dotnet test LibGit2Sharp.sln --configuration Release --framework ${{ matrix.tfm }} --logger "GitHubActions" /p:ExtraDefine=LEAKS_IDENTIFYING
+    test-linux:
+        name: Test / ${{ matrix.distro }} / ${{ matrix.arch }} / ${{ matrix.tfm }}
+        runs-on: ${{ matrix.runnerImage }}
+        strategy:
+            matrix:
+                arch: [amd64, arm64]
+                distro:
+                    [
+                        alpine.3.20,
+                        alpine.3.21,
+                        alpine.3.22,
+                        centos.stream.9,
+                        debian.12,
+                        fedora.41,
+                        fedora.42,
+                        ubuntu.22.04,
+                        ubuntu.24.04,
+                    ]
+                sdk: ["8.0", "9.0"]
+                include:
+                    - sdk: "8.0"
+                      tfm: net8.0
+                    - sdk: "9.0"
+                      tfm: net9.0
+                    - arch: amd64
+                      runnerImage: ubuntu-22.04
+                    - arch: arm64
+                      runnerImage: ubuntu-22.04-arm
+            fail-fast: false
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v6
+              with:
+                  fetch-depth: 0
+            - name: Run ${{ matrix.tfm }} tests
+              run: |
+                  git_command="git config --global --add safe.directory /app"
+                  test_command="dotnet test LibGit2Sharp.sln --configuration Release -p:TargetFrameworks=${{ matrix.tfm }} --logger "GitHubActions" -p:ExtraDefine=LEAKS_IDENTIFYING"
+                  docker run -t --rm --platform linux/${{ matrix.arch }} -v "$PWD:/app" -w /app -e OPENSSL_ENABLE_SHA1_SIGNATURES=1 gittools/build-images:${{ matrix.distro }}-sdk-${{ matrix.sdk }} sh -c "$git_command && $test_command"
+
+    nuget-push:
+        name: Octopus NuGet Push
+        needs: [build, test, test-linux]
+        # &&  github.ref == 'refs/heads/octopus/master'
+        if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]' && github.event_name != 'schedule'
+        runs-on: ubuntu-22.04
+        steps:
+            - uses: actions/download-artifact@v8
+
+              with:
+                  path: staging
+            - name: Push package to feed 🐙
+              id: push-feed
+              shell: bash
+              env:
+                  FEED_API_KEY: ${{ secrets.FEED_API_KEY }}
+                  FEED_SOURCE: ${{ secrets.FEED_SOURCE }}
+              run: dotnet nuget push staging/**/*.nupkg --api-key "$FEED_API_KEY" --source "$FEED_SOURCE" --skip-duplicate

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ _ReSharper*/
 *.swp
 *.DotSettings
 
+.idea/
 _NCrunch_LibGit2Sharp/
 artifacts/
 worktree.playlist

--- a/.idea/.idea.LibGit2Sharp/.idea/indexLayout.xml
+++ b/.idea/.idea.LibGit2Sharp/.idea/indexLayout.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="UserContentModel">
-    <attachedFolders />
+    <attachedFolders>
+      <Path>.</Path>
+    </attachedFolders>
     <explicitIncludes />
     <explicitExcludes />
   </component>

--- a/LibGit2Sharp.Tests/GlobalSettingsFixture.cs
+++ b/LibGit2Sharp.Tests/GlobalSettingsFixture.cs
@@ -90,17 +90,17 @@ namespace LibGit2Sharp.Tests
             var extensions = GlobalSettings.GetExtensions();
 
             // Assert that "noop" is supported by default
-            Assert.Equal(new[] { "noop", "objectformat", "worktreeconfig" }, extensions);
+            Assert.Equal(new[] { "noop", "objectformat", "preciousobjects", "worktreeconfig" }, extensions);
 
             // Disable "noop" extensions
             GlobalSettings.SetExtensions("!noop");
             extensions = GlobalSettings.GetExtensions();
-            Assert.Equal(new[] { "objectformat", "worktreeconfig" }, extensions);
+            Assert.Equal(new[] { "objectformat", "preciousobjects", "worktreeconfig" }, extensions);
 
             // Enable two new extensions (it will reset the configuration and "noop" will be enabled)
             GlobalSettings.SetExtensions("partialclone", "newext");
             extensions = GlobalSettings.GetExtensions();
-            Assert.Equal(new[] { "newext", "noop", "objectformat", "partialclone", "worktreeconfig" }, extensions);
+            Assert.Equal(new[] { "newext", "noop", "objectformat", "partialclone", "preciousobjects", "worktreeconfig" }, extensions);
         }
 
         [Fact]

--- a/LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj
+++ b/LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(TargetFrameworks)'==''">net472;net6.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetFrameworks)'==''">net472;net8.0;net9.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/LibGit2Sharp/Core/GitBlame.cs
+++ b/LibGit2Sharp/Core/GitBlame.cs
@@ -61,12 +61,15 @@ namespace LibGit2Sharp.Core
         public git_oid final_commit_id;
         public UIntPtr final_start_line_number;
         public git_signature* final_signature;
+        public git_signature* final_committer;
 
         public git_oid orig_commit_id;
         public char* orig_path;
         public UIntPtr orig_start_line_number;
         public git_signature* orig_signature;
+        public git_signature* orig_committer;
 
+        public char* summary;
         public byte boundary;
     }
 

--- a/LibGit2Sharp/Core/GitCertificateSsh.cs
+++ b/LibGit2Sharp/Core/GitCertificateSsh.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.InteropServices;
+﻿using System;
+using System.Runtime.InteropServices;
 
 namespace LibGit2Sharp.Core
 {
@@ -17,5 +18,14 @@ namespace LibGit2Sharp.Core
         /// The SHA1 hash (if appropriate)
         /// </summary>
         public unsafe fixed byte HashSHA1[20];
+
+        /// <summary>
+        /// The SHA256 hash (if appropriate)
+        /// </summary>
+        public unsafe fixed byte HashSHA256[32];
+
+        public int raw_type;
+        public byte* hostkey;
+        public UIntPtr hostkey_len;
     }
 }

--- a/LibGit2Sharp/Core/GitCertificateSshType.cs
+++ b/LibGit2Sharp/Core/GitCertificateSshType.cs
@@ -7,5 +7,6 @@ namespace LibGit2Sharp.Core
     {
         MD5 = (1 << 0),
         SHA1 = (1 << 1),
+        SHA256 = (1 << 2),
     }
 }

--- a/LibGit2Sharp/Core/GitCheckoutOpts.cs
+++ b/LibGit2Sharp/Core/GitCheckoutOpts.cs
@@ -7,14 +7,9 @@ namespace LibGit2Sharp.Core
     internal enum CheckoutStrategy
     {
         /// <summary>
-        /// Default is a dry run, no actual updates.
+        /// Allow safe updates that cannot overwrite uncommitted data.
         /// </summary>
-        GIT_CHECKOUT_NONE = 0,
-
-        /// <summary>
-        /// Allow safe updates that cannot overwrite uncommited data.
-        /// </summary>
-        GIT_CHECKOUT_SAFE = (1 << 0),
+        GIT_CHECKOUT_SAFE = 0,
 
         /// <summary>
         /// Allow update of entries in working dir that are modified from HEAD.
@@ -104,6 +99,22 @@ namespace LibGit2Sharp.Core
         /// Normally checkout writes the index upon completion; this prevents that.
         /// </summary>
         GIT_CHECKOUT_DONT_WRITE_INDEX = (1 << 23),
+
+        /// <summary>
+        /// Perform a dry run, reporting what would be done but without
+        /// actually making changes in the working directory or the index.
+        /// </summary>
+        GIT_CHECKOUT_DRY_RUN = (1 << 24),
+
+        /// <summary>
+        /// Include common ancestor data in zdiff3 format for conflicts.
+        /// </summary>
+        GIT_CHECKOUT_CONFLICT_STYLE_ZDIFF3 = (1 << 25),
+
+        /// <summary>
+        /// Do not do a checkout and do not fire callbacks.
+        /// </summary>
+        GIT_CHECKOUT_NONE = (1 << 30),
 
         // THE FOLLOWING OPTIONS ARE NOT YET IMPLEMENTED
 

--- a/LibGit2Sharp/Core/GitConfigEntry.cs
+++ b/LibGit2Sharp/Core/GitConfigEntry.cs
@@ -11,6 +11,5 @@ namespace LibGit2Sharp.Core
         public char* origin_path;
         public uint include_depth;
         public uint level;
-        public void* freePtr;
     }
 }

--- a/LibGit2Sharp/Core/GitDiff.cs
+++ b/LibGit2Sharp/Core/GitDiff.cs
@@ -230,6 +230,7 @@ namespace LibGit2Sharp.Core
 
         public uint ContextLines;
         public uint InterhunkLines;
+        public uint OidType;
         public ushort IdAbbrev;
         public long MaxSize;
         public IntPtr OldPrefixString;

--- a/LibGit2Sharp/Core/GitRebaseOptions.cs
+++ b/LibGit2Sharp/Core/GitRebaseOptions.cs
@@ -21,5 +21,7 @@ namespace LibGit2Sharp.Core
         private IntPtr padding; // TODO: add git_commit_create_cb
 
         public NativeMethods.commit_signing_callback signing_callback;
+
+        public IntPtr payload;
     }
 }

--- a/LibGit2Sharp/Core/GitRemoteCallbacks.cs
+++ b/LibGit2Sharp/Core/GitRemoteCallbacks.cs
@@ -38,5 +38,7 @@ namespace LibGit2Sharp.Core
         internal IntPtr payload;
 
         internal NativeMethods.url_resolve_callback resolve_url;
+
+        internal IntPtr update_refs;
     }
 }

--- a/LibGit2Sharp/Core/GitStatusOptions.cs
+++ b/LibGit2Sharp/Core/GitStatusOptions.cs
@@ -15,6 +15,8 @@ namespace LibGit2Sharp.Core
 
         public IntPtr Baseline = IntPtr.Zero;
 
+        public ushort RenameThreshold;
+
         public void Dispose()
         {
             PathSpec.Dispose();

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -30,7 +30,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="[2.0.323]" PrivateAssets="none" />
+    <PackageReference Include="Octopus.LibGit2Sharp.NativeBinaries" Version="2.0.323-octopus.1" PrivateAssets="none" />
     <PackageReference Include="MinVer" Version="6.0.0" PrivateAssets="all" />
   </ItemGroup>
 

--- a/nuget.config
+++ b/nuget.config
@@ -2,5 +2,6 @@
 <configuration>
   <packageSources>
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="feedz.io" value="https://f.feedz.io/octopus-deploy/dependencies/nuget/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
Takes the [new fork we've created of the native binaries](https://github.com/OctopusDeploy/libgit2sharp.nativebinaries), which is updated to fix the build which included an update to the libgit2 version (v1.8.4 to v1.9.2) that was required to get it running on arm mac agents.

This PR is split out to include only changes required by the libgit2 update - primarily struct updates - so that it can be merged upstream if the native binaries changes are accepted upstream too.

Relates to MD-1601