### PR TITLE
Include static windows binaries

### DIFF
--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -30,7 +30,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Octopus.LibGit2Sharp.NativeBinaries" Version="2.0.323-octopus.4.octopus-em-static-wi.65" PrivateAssets="none" />
+    <PackageReference Include="Octopus.LibGit2Sharp.NativeBinaries" Version="2.0.323-octopus.5" PrivateAssets="none" />
     <PackageReference Include="MinVer" Version="6.0.0" PrivateAssets="all" />
   </ItemGroup>
 

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -30,7 +30,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Octopus.LibGit2Sharp.NativeBinaries" Version="2.0.323-octopus.4" PrivateAssets="none" />
+    <PackageReference Include="Octopus.LibGit2Sharp.NativeBinaries" Version="2.0.323-octopus.4.octopus-em-static-wi.62" PrivateAssets="none" />
     <PackageReference Include="MinVer" Version="6.0.0" PrivateAssets="all" />
   </ItemGroup>
 

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -30,7 +30,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Octopus.LibGit2Sharp.NativeBinaries" Version="2.0.323-octopus.4.octopus-em-static-wi.62" PrivateAssets="none" />
+    <PackageReference Include="Octopus.LibGit2Sharp.NativeBinaries" Version="2.0.323-octopus.4.octopus-em-static-wi.65" PrivateAssets="none" />
     <PackageReference Include="MinVer" Version="6.0.0" PrivateAssets="all" />
   </ItemGroup>
 


### PR DESCRIPTION
Pulls in changes from https://github.com/OctopusDeploy/libgit2sharp.nativebinaries/pull/13

Tested with a small repro app that lists branches using SSH auth on windows (vm), linux (container) and mac

Related to MD-2027